### PR TITLE
Clean up black.FileMode initialization

### DIFF
--- a/uqbar/book/sphinx.py
+++ b/uqbar/book/sphinx.py
@@ -22,7 +22,7 @@ try:
 
     def black_format(lines):
         mode = black.FileMode(
-            line_length=80, target_versions=[black.TargetVersion.PY36]
+            line_length=80, target_versions=set([black.TargetVersion.PY36])
         )
         return black.format_str("\n".join(lines), mode=mode).splitlines()
 


### PR DESCRIPTION
Black 22.1.0 (2022-01-29) breaks when `black.FileMode.target_versions` is passed as a list.

The patch here changes `target_version` to a set; APIs test correctly with the version of black and with older versions of the package, too.