### PR TITLE
Add uqbar_api_omit_inheritance_diagrams config parameter.

### DIFF
--- a/uqbar/apis/APIBuilder.py
+++ b/uqbar/apis/APIBuilder.py
@@ -53,6 +53,7 @@ class APIBuilder(object):
         :py:class:`~uqbar.apis.MemberDocumenter` subclasses, defining what classes
         to use to identify and document module members
     :param module_documenter_class: a :py:class:`~uqbar.apis.ModuleDocumenter` subclass
+    :param omit_inheritance_diagrams: whether to omit inheritance diagrams
     :param root_documenter_class: a :py:class:`~uqbar.apis.RootDocumenter` subclass
     """
 
@@ -67,6 +68,7 @@ class APIBuilder(object):
         document_private_modules: bool = False,
         member_documenter_classes: Sequence[Type[MemberDocumenter]] = None,
         module_documenter_class: Type[ModuleDocumenter] = None,
+        omit_inheritance_diagrams: bool = False,
         omit_root: bool = False,
         root_documenter_class: Type[RootDocumenter] = None,
         title: str = "API",
@@ -89,7 +91,10 @@ class APIBuilder(object):
         if module_documenter_class is None:
             module_documenter_class = ModuleDocumenter
         assert issubclass(module_documenter_class, ModuleDocumenter)
+        omit_inheritance_diagrams = bool(omit_inheritance_diagrams)
+        module_documenter_class.omit_inheritance_diagrams = omit_inheritance_diagrams
         self._module_documenter_class = module_documenter_class
+        self._omit_inheritance_diagrams = bool(omit_inheritance_diagrams)
         self._omit_root = bool(omit_root)
         if root_documenter_class is None:
             root_documenter_class = RootDocumenter
@@ -283,6 +288,10 @@ class APIBuilder(object):
     @property
     def module_documenter_class(self):
         return self._module_documenter_class
+
+    @property
+    def omit_inheritance_diagrams(self):
+        return self._omit_inheritance_diagrams
 
     @property
     def omit_root(self):

--- a/uqbar/apis/SummarizingModuleDocumenter.py
+++ b/uqbar/apis/SummarizingModuleDocumenter.py
@@ -107,15 +107,16 @@ class SummarizingModuleDocumenter(ModuleDocumenter):
         result = self._build_preamble()
         package_path = self.package_path.partition(".")[0]
         lineage_path = self.package_path
-        result.extend(
-            [
-                "",
-                ".. container:: svg-container",
-                "",
-                "   .. inheritance-diagram:: {}".format(package_path),
-                "      :lineage: {}".format(lineage_path),
-            ]
-        )
+        if not self.omit_inheritance_diagrams:
+            result.extend(
+                [
+                    "",
+                    ".. container:: svg-container",
+                    "",
+                    "   .. inheritance-diagram:: {}".format(package_path),
+                    "      :lineage: {}".format(lineage_path),
+                ]
+            )
         if self.is_nominative:
             result.extend(["", str(self.member_documenters[0])])
         else:

--- a/uqbar/sphinx/api.py
+++ b/uqbar/sphinx/api.py
@@ -13,6 +13,7 @@ the initialization arguments to the :py:class:`uqbar.apis.APIBuilder` class.
 - ``uqbar_api_document_private_modules`` (default: ``False``)
 - ``uqbar_api_member_documenter_classes`` (default: ``None``)
 - ``uqbar_api_module_documenter_class`` (default: ``None``)
+- ``uqbar_api_omit_inheritance_diagrams`` (default: ``False``)
 - ``uqbar_api_root_documenter_class`` (default: ``None``)
 - ``uqbar_api_source_paths`` (default: ``[]``)
 - ``uqbar_api_title`` (default: ``API``)
@@ -100,6 +101,7 @@ def on_builder_inited(app):
         document_private_modules=config.uqbar_api_document_private_modules,
         member_documenter_classes=member_documenter_classes or None,
         module_documenter_class=module_documenter_class,
+        omit_inheritance_diagrams=config.uqbar_api_omit_inheritance_diagrams,
         omit_root=config.uqbar_api_omit_root,
         root_documenter_class=root_documenter_class,
         title=config.uqbar_api_title,
@@ -118,6 +120,7 @@ def setup(app) -> Dict[str, Any]:
     app.add_config_value("uqbar_api_document_private_modules", False, "env")
     app.add_config_value("uqbar_api_member_documenter_classes", None, "env")
     app.add_config_value("uqbar_api_module_documenter_class", None, "env")
+    app.add_config_value("uqbar_api_omit_inheritance_diagrams", False, "env")
     app.add_config_value("uqbar_api_omit_root", False, "env")
     app.add_config_value("uqbar_api_root_documenter_class", None, "env")
     app.add_config_value("uqbar_api_source_paths", None, "env")


### PR DESCRIPTION
Uqbar 0.5.9 appears to provide no way for users to suppress the
generation of inheritance diagrams during API build. (Removing
uqbar.sphinx.inheritance from the list of extensions in conf.py
generates errors during API build because SummarizingModuleDocumenter
continues to write inheritance-diagram directives into .rst files even
when no inheritance diagrams are produced.)

This PR adds an uqbar_api_omit_inheritance_diagrams config parameter.
The parameter is settable in conf.py, and defaults to false. When true,
APIBuilder sets an omit_inheritance_diagrams property on module
documenter objects; SummarizingModuleDocumenter knows about this
parameter and suppresses inheritance-diagram directives in .rst output
when true.